### PR TITLE
R77 tweaks

### DIFF
--- a/all-services.jenkinsfile
+++ b/all-services.jenkinsfile
@@ -37,7 +37,7 @@ pipeline
                     script
                     {
                         sh "ls -lht"
-                        docker.build("reactome/graphdb:${env.RELEASE_VERSION} --no-cache --build-arg GRAPHDB_LOCATION=reactome-${env.RELEASE_VERSION}.graphdb.tgz --build-arg RELEASE_VERSION=${env.RELEASE_VERSION} -f ./neo4j_stand-alone.dockerfile")
+                        docker.build("reactome/graphdb:${env.RELEASE_VERSION} --build-arg GRAPHDB_LOCATION=reactome-${env.RELEASE_VERSION}.graphdb.tgz --build-arg RELEASE_VERSION=${env.RELEASE_VERSION} -f ./neo4j_stand-alone.dockerfile")
                     }
                 }
             }

--- a/all-services.jenkinsfile
+++ b/all-services.jenkinsfile
@@ -142,7 +142,8 @@ pipeline
                     script
                     {
                       // Make sure you set up the github Personal Access Token before this step runs.
-                        docker.build("reactome/analysis-service-and-pwb:${env.RELEASE_VERSION} --build-arg RELEASE_VERSION=${env.RELEASE_VERSION} -f pathway-browser.dockerfile")
+                      // you can (re-)generate your github token in Github by going to Settings -> Developer Settings -> Personal Access Token
+                        docker.build("reactome/analysis-service-and-pwb:${env.RELEASE_VERSION} --build-arg RELEASE_VERSION=${env.RELEASE_VERSION} --build-arg GITHUB_TOKEN=${env.GITHUB_TOKEN} -f pathway-browser.dockerfile")
                     }
                 }
             }

--- a/build_all.sh
+++ b/build_all.sh
@@ -3,7 +3,7 @@
 # simple script to build ALL of the images necessary to run Reactome in docker containers.
 
 #TODO: get the Release version as well as Neo4j username/password from a file.
-RELEASE_VERSION=Release75
+RELEASE_VERSION=Release77
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=n304j
 set -e

--- a/build_browser_and_analysisservice.sh
+++ b/build_browser_and_analysisservice.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-RELEASE_VERSION=Release76
+RELEASE_VERSION=Release77
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4j-password
 
@@ -48,7 +48,8 @@ docker build -t reactome/diagram-generator:${RELEASE_VERSION} \
 # You will need to generate a Personal Access Token to access the Reacfoam repo. Save it in a file "github.token"
 # Make sure you give the token the permissions: repo (repo:status, repo_deployment, public_repo, repo:invite, security_events) and read:repo_hook
 cd $STARTING_DIR/pathway-browser
-GITHUB_TOKEN=$(cat github.token)
+set -x
+GITHUB_TOKEN=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
 echo -e "===\nBuilding analysis-service + PathwayBrowser image...\n"
 docker build -t reactome/analysis-service-and-pwb:${RELEASE_VERSION} \
 	--build-arg NEO4J_USER=$NEO4J_USER \
@@ -56,7 +57,7 @@ docker build -t reactome/analysis-service-and-pwb:${RELEASE_VERSION} \
 	--build-arg RELEASE_VERSION=$RELEASE_VERSION \
 	--build-arg GITHUB_TOKEN=$GITHUB_TOKEN \
 	-f pathway-browser.dockerfile .
-
+set +x
 cd $STARTING_DIR
 
 echo -e "===\nImages built: "

--- a/build_browser_and_analysisservice.sh
+++ b/build_browser_and_analysisservice.sh
@@ -49,7 +49,7 @@ docker build -t reactome/diagram-generator:${RELEASE_VERSION} \
 # Make sure you give the token the permissions: repo (repo:status, repo_deployment, public_repo, repo:invite, security_events) and read:repo_hook
 cd $STARTING_DIR/pathway-browser
 set -x
-GITHUB_TOKEN=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
+GITHUB_TOKEN=$(cat github.token)
 echo -e "===\nBuilding analysis-service + PathwayBrowser image...\n"
 docker build -t reactome/analysis-service-and-pwb:${RELEASE_VERSION} \
 	--build-arg NEO4J_USER=$NEO4J_USER \

--- a/build_standalone_analysisservice.sh
+++ b/build_standalone_analysisservice.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-RELEASE_VERSION=Release76
+RELEASE_VERSION=Release77
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4j-password
 

--- a/build_standalone_contentservice.sh
+++ b/build_standalone_contentservice.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-RELEASE_VERSION=Release76
+RELEASE_VERSION=Release77
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=neo4j-password
 
@@ -37,9 +37,17 @@ docker build -t reactome/diagram-generator:${RELEASE_VERSION} \
 	--build-arg RELEASE_VERSION=$RELEASE_VERSION \
 	-f diagram-generator.dockerfile .
 
+echo -e "===\nGenerating Fireworks files...\n"
+cd $STARTING_DIR/fireworks-generator
+docker build -t reactome/fireworks-generator:$RELEASE_VERSION \
+	--build-arg RELEASE_VERSION=$RELEASE_VERSION \
+	--build-arg NEO4J_USER=$NEO4J_USER \
+	--build-arg NEO4J_PASSWORD=$NEO4J_PASSWORD \
+	-f fireworks-generator.dockerfile .
+
 echo -e "===\nBuilding content-service image...\n"
 cd $STARTING_DIR/stand-alone-content-service
-docker build -t reactome/stand-alone-content-service \
+docker build -t reactome/stand-alone-content-service:${RELEASE_VERSION} \
 	--build-arg NEO4J_USER=$NEO4J_USER \
 	--build-arg NEO4J_PASSWORD=$NEO4J_PASSWORD \
 	--build-arg RELEASE_VERSION=$RELEASE_VERSION \
@@ -51,5 +59,5 @@ echo -e "===\nImages built: "
 # We are building 4 "reactome" images, so lets display them
 docker images | grep "reactome" | head -n 4
 
-echo -e "Now you can run the stand-alone content-service like this:\n'docker run --name reactome-content-service -p 8080:8080 reactome/stand-alone-content-service:Release${RELEASE_VERSION}'"
+echo -e "Now you can run the stand-alone content-service like this:\n'docker run --name reactome-content-service -p 8080:8080 reactome/stand-alone-content-service:${RELEASE_VERSION}'"
 set +e

--- a/diagram-generator/diagram-generator.dockerfile
+++ b/diagram-generator/diagram-generator.dockerfile
@@ -58,7 +58,7 @@ WORKDIR /
 COPY ./generate_diagrams.sh /diagram-converter/generate_diagrams.sh
 # neo4j-entrypoint expects su-exec, but there doesn't seem to be a package for that. gosu should be able to do the same thing.
 # The sed line below is to make Java more compatible with MySQL 5.7 because I can't seem to get MySQL 5.7 working with TLSv1.2
-RUN apt-get install software-properties-common -y -qq \
+RUN apt-get update && apt-get install software-properties-common -y -qq \
   && apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
   && mkdir -p /usr/share/man/man1 && \
   apt-get update && apt-get install gosu openjdk-8-jdk-headless openjdk-8-jre-headless netcat -y -qq \

--- a/diagram-generator/diagram-generator.dockerfile
+++ b/diagram-generator/diagram-generator.dockerfile
@@ -57,10 +57,14 @@ RUN ln -s /var/lib/neo4j/conf /conf
 WORKDIR /
 COPY ./generate_diagrams.sh /diagram-converter/generate_diagrams.sh
 # neo4j-entrypoint expects su-exec, but there doesn't seem to be a package for that. gosu should be able to do the same thing.
-RUN mkdir -p /usr/share/man/man1 && \
-  apt-get update && apt-get install gosu openjdk-8-jdk-headless openjdk-8-jre-headless netcat -y \
+# The sed line below is to make Java more compatible with MySQL 5.7 because I can't seem to get MySQL 5.7 working with TLSv1.2
+RUN apt-get install software-properties-common -y -qq \
+  && apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
+  && mkdir -p /usr/share/man/man1 && \
+  apt-get update && apt-get install gosu openjdk-8-jdk-headless openjdk-8-jre-headless netcat -y -qq \
   && ln -s  $(which gosu) /bin/su-exec \
   && mkdir /diagrams \
+  && sed -i 's/\(jdk\.tls\.disabledAlgorithms=.*\)\(TLSv1, TLSv1.1,\)\(.*\)/\1\3/g' /etc/java-8-openjdk/security/java.security \
   && chmod a+x /diagram-converter/generate_diagrams.sh && /diagram-converter/generate_diagrams.sh
 
 # Ok, now that diagrams are generated, maybe we should rebase on something smaller and only copy over what we need.

--- a/diagram-generator/generate_diagrams.sh
+++ b/diagram-generator/generate_diagrams.sh
@@ -12,10 +12,6 @@ bash /neo4j-entrypoint.sh neo4j &
 echo "Waiting for Neo4j..."
 bash /wait-for.sh localhost:7687 -t 120 && bash /wait-for.sh localhost:7474 -t 120
 
-# tried forcing TLS 1.2 but that didn't seem to work...
-# echo "tls_version=TLSv1.2" >> /etc/mysql/mysql.cnf
-# echo "require_secure_transport=ON" >> /etc/mysql/mysql.cnf
-
 # Start MySQL
 /usr/local/bin/docker-entrypoint.sh mysqld &
 # service mysqld start &
@@ -28,7 +24,6 @@ echo -e "\n\n" > /etc/java-8-openjdk/accessibility.properties
 echo "Running diagram generator..."
 # Run the diagram generator
 # NOTE: NEO4J_USER and NEO4J_PASSWORD are set in the dockerfile.
-# Tried to force TLS 1.2 with " -Djdk.tls.client.protocols=TLSv1.2 -Dhttps.protocols=TLSv1.2" but it didn't seem to work.
 cd /diagram-converter/
 java -jar /diagram-converter/diagram-converter-jar-with-dependencies.jar \
 	 -a localhost \

--- a/diagram-generator/generate_diagrams.sh
+++ b/diagram-generator/generate_diagrams.sh
@@ -12,6 +12,10 @@ bash /neo4j-entrypoint.sh neo4j &
 echo "Waiting for Neo4j..."
 bash /wait-for.sh localhost:7687 -t 120 && bash /wait-for.sh localhost:7474 -t 120
 
+# tried forcing TLS 1.2 but that didn't seem to work...
+# echo "tls_version=TLSv1.2" >> /etc/mysql/mysql.cnf
+# echo "require_secure_transport=ON" >> /etc/mysql/mysql.cnf
+
 # Start MySQL
 /usr/local/bin/docker-entrypoint.sh mysqld &
 # service mysqld start &
@@ -24,6 +28,7 @@ echo -e "\n\n" > /etc/java-8-openjdk/accessibility.properties
 echo "Running diagram generator..."
 # Run the diagram generator
 # NOTE: NEO4J_USER and NEO4J_PASSWORD are set in the dockerfile.
+# Tried to force TLS 1.2 with " -Djdk.tls.client.protocols=TLSv1.2 -Dhttps.protocols=TLSv1.2" but it didn't seem to work.
 cd /diagram-converter/
 java -jar /diagram-converter/diagram-converter-jar-with-dependencies.jar \
 	 -a localhost \

--- a/mysql/mysql.dockerfile
+++ b/mysql/mysql.dockerfile
@@ -2,7 +2,7 @@
 #    docker build -t reactome/reactome-mysql:R67 -f mysql.dockerfile .
 # Run as:
 #    docker run --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=gk_current reactome/reactome-mysql:R67
-FROM mysql:5.7.24
+FROM mysql:5.7.34
 ARG MYSQL_ROOT_PASSWORD=root
 ARG RELEASE_VERSION=Release74
 LABEL ReleaseVersion ${RELEASE_VERSION}

--- a/pathway-browser/entrypoint.sh
+++ b/pathway-browser/entrypoint.sh
@@ -12,6 +12,14 @@ bash /neo4j-entrypoint.sh neo4j &
 echo "Waiting for Neo4j..."
 bash /wait-for.sh localhost:7687 -t 90 && bash /wait-for.sh localhost:7474 -t 90
 
+echo "Waiting for solr..."
+su-exec solr solr-foreground &
+bash /wait-for.sh localhost:8983 -t 120
+
+echo "Waiting for MySQL..."
+mysqld --user=root &
+bash /wait-for.sh localhost:3306 -t 120
+
 echo "Starting tomcat..."
 # Now that Neo4j has been started, we can run tomcat
 cd /usr/local/tomcat

--- a/pathway-browser/pathway-browser.dockerfile
+++ b/pathway-browser/pathway-browser.dockerfile
@@ -1,4 +1,4 @@
-ARG RELEASE_VERSION=Release75
+ARG RELEASE_VERSION=Release77
 FROM maven:3.6.3-jdk-8 AS builder
 ENV PATHWAY_BROWSER_VERSION=master
 RUN mkdir -p /gitroot && \
@@ -29,10 +29,13 @@ RUN git clone https://github.com/reactome-pwp/browser.git \
 	&& sed -i 's/<neo4j\.password>.*<\/neo4j\.password>/<neo4j.password>'${NEO4J_PASSWORD}'<\/neo4j.password>/g'  /maven-settings.xml \
   && $MVN_CMD gwt:import-sources compile package \
   && mv /gitroot/browser/target/PathwayBrowser*.war /webapps/PathwayBrowser.war
-# COPY github.token /tmp/github.token
+
+# You will need to generate a Personal Access Token to access the Reacfoam repo. Save it in a file "github.token"
+# Make sure you give the token the permissions: repo (repo:status, repo_deployment, public_repo, repo:invite, security_events) and read:repo_hook
+# use "--build-arg GITHUB_TOKEN=$(cat github.token)" when you build this image.
 ARG GITHUB_TOKEN
 RUN cd /webapps && git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/reactome-pwp/reacfoam.git && cd reacfoam && git checkout demo-version && rm -rf .git
-# && rm /tmp/github.token
+
 RUN git clone https://github.com/reactome/experiment-digester.git
 
 RUN cd /gitroot/experiment-digester \
@@ -51,15 +54,11 @@ RUN cp /experiments.bin /webapps/experiments.bin
 
 FROM reactome/analysis-core:${RELEASE_VERSION} AS analysiscorebuilder
 FROM reactome/stand-alone-analysis-service:${RELEASE_VERSION} AS analysisservice
-# FROM reactome/graphdb:${RELEASE_VERSION} AS graphdb
-# FROM reactome/fireworks-generator:${RELEASE_VERSION} as fireworks
-# FROM reactome/diagram-generator:${RELEASE_VERSION} as diagrams
 # Use content-service as the final base-layer because
 # it already contains Tomcat, ContentService, MySQL, Neo4j, Solr,
 # Fireworks, and Diagrams
 FROM reactome/stand-alone-content-service:${RELEASE_VERSION}
-# Ok, now re-base the image as Tomcat
-# FROM tomcat:8.5.35-jre8
+
 ENV EXTENSION_SCRIPT=/data/neo4j-init.sh
 ENV NEO4J_EDITION=community
 ARG NEO4J_USER=neo4j
@@ -77,31 +76,15 @@ RUN mkdir -p /usr/local/diagram/static && \
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN mkdir -p /usr/local/AnalysisService/analysis-results \
-  # && useradd neo4j \
   && chmod a+x /entrypoint.sh
-# Copy the analysis file
-# COPY --from=fireworks /fireworks-json-files /tmp/fireworks
-# ContentService expects fireworks to be in a different location...
-# And since we're relying on a pre-built image for ContentService AND AnalysisService,
-# It's easier to just put Fireworks in both places. Future TODO: make all images use the same location, for consistency.
+
 RUN mkdir -p /usr/local/tomcat/webapps/download/current/
-#	 && cp -r /tmp/fireworks /usr/local/tomcat/webapps/download/current/fireworks \
-#	 && rm -rf /tmp/fireworks
 
 COPY --from=analysiscorebuilder /output/analysis.bin /analysis.bin
 # Copy the web applications created in the builder stage.
 COPY --from=builder /webapps/ /usr/local/tomcat/webapps/
 COPY --from=builder /webapps/experiments.bin /experiments.bin
-# Copy graph database
-# COPY --from=graphdb /data/neo4j-init.sh /data/neo4j-init.sh
-# COPY --from=graphdb /docker-entrypoint.sh /neo4j-entrypoint.sh
-# COPY --from=graphdb /var/lib/neo4j /var/lib/neo4j
-# COPY --from=graphdb /logs /var/lib/neo4j/logs
-# COPY --from=graphdb /var/lib/neo4j/conf/neo4j.conf /var/lib/neo4j/conf/neo4j.conf
-# COPY --from=graphdb /data /var/lib/neo4j/data
 COPY --from=analysisservice /usr/local/tomcat/webapps/AnalysisService.war /usr/local/tomcat/webapps/AnalysisService.war
-# COPY --from=contentservice /usr/local/tomcat/webapps/ContentService.war /usr/local/tomcat/webapps/ContentService.war
-# COPY --from=diagrams /diagrams /usr/local/tomcat/webapps/download/current/diagram
 COPY ./wait-for.sh /wait-for.sh
 
 # Set up links to fireworks files for reacfoam
@@ -120,6 +103,5 @@ RUN mkdir -p /usr/local/tomcat/webapps/download/META-INF/ && \
 	echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Context path=\"/download\"><Resources allowLinking=\"true\"></Resources></Context>" > /usr/local/tomcat/webapps/download/META-INF/context.xml
 # load and set entrypoint
 CMD ["/entrypoint.sh"]
-# This is already done in the content-service layer
-# RUN ln -s  $(which gosu) /bin/su-exec
+
 # Run this as: docker run --name reactome-analysis-service -p 8080:8080 reactome/stand-alone-analysis-service:Release71

--- a/pathway-browser/pathway-browser.dockerfile
+++ b/pathway-browser/pathway-browser.dockerfile
@@ -51,12 +51,15 @@ RUN cp /experiments.bin /webapps/experiments.bin
 
 FROM reactome/analysis-core:${RELEASE_VERSION} AS analysiscorebuilder
 FROM reactome/stand-alone-analysis-service:${RELEASE_VERSION} AS analysisservice
-FROM reactome/stand-alone-content-service:${RELEASE_VERSION} AS contentservice
-FROM reactome/graphdb:${RELEASE_VERSION} AS graphdb
-FROM reactome/fireworks-generator:${RELEASE_VERSION} as fireworks
-FROM reactome/diagram-generator:${RELEASE_VERSION} as diagrams
+# FROM reactome/graphdb:${RELEASE_VERSION} AS graphdb
+# FROM reactome/fireworks-generator:${RELEASE_VERSION} as fireworks
+# FROM reactome/diagram-generator:${RELEASE_VERSION} as diagrams
+# Use content-service as the final base-layer because
+# it already contains Tomcat, ContentService, MySQL, Neo4j, Solr,
+# Fireworks, and Diagrams
+FROM reactome/stand-alone-content-service:${RELEASE_VERSION}
 # Ok, now re-base the image as Tomcat
-FROM tomcat:8.5.35-jre8
+# FROM tomcat:8.5.35-jre8
 ENV EXTENSION_SCRIPT=/data/neo4j-init.sh
 ENV NEO4J_EDITION=community
 ARG NEO4J_USER=neo4j
@@ -74,31 +77,31 @@ RUN mkdir -p /usr/local/diagram/static && \
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN mkdir -p /usr/local/AnalysisService/analysis-results \
-  && useradd neo4j \
+  # && useradd neo4j \
   && chmod a+x /entrypoint.sh
 # Copy the analysis file
-COPY --from=fireworks /fireworks-json-files /tmp/fireworks
+# COPY --from=fireworks /fireworks-json-files /tmp/fireworks
 # ContentService expects fireworks to be in a different location...
 # And since we're relying on a pre-built image for ContentService AND AnalysisService,
 # It's easier to just put Fireworks in both places. Future TODO: make all images use the same location, for consistency.
-RUN mkdir -p /usr/local/tomcat/webapps/download/current/ \
-	&& cp -r /tmp/fireworks /usr/local/tomcat/webapps/download/current/fireworks \
-	&& rm -rf /tmp/fireworks
+RUN mkdir -p /usr/local/tomcat/webapps/download/current/
+#	 && cp -r /tmp/fireworks /usr/local/tomcat/webapps/download/current/fireworks \
+#	 && rm -rf /tmp/fireworks
 
 COPY --from=analysiscorebuilder /output/analysis.bin /analysis.bin
 # Copy the web applications created in the builder stage.
 COPY --from=builder /webapps/ /usr/local/tomcat/webapps/
 COPY --from=builder /webapps/experiments.bin /experiments.bin
 # Copy graph database
-COPY --from=graphdb /data/neo4j-init.sh /data/neo4j-init.sh
-COPY --from=graphdb /docker-entrypoint.sh /neo4j-entrypoint.sh
-COPY --from=graphdb /var/lib/neo4j /var/lib/neo4j
-COPY --from=graphdb /logs /var/lib/neo4j/logs
-COPY --from=graphdb /var/lib/neo4j/conf/neo4j.conf /var/lib/neo4j/conf/neo4j.conf
-COPY --from=graphdb /data /var/lib/neo4j/data
+# COPY --from=graphdb /data/neo4j-init.sh /data/neo4j-init.sh
+# COPY --from=graphdb /docker-entrypoint.sh /neo4j-entrypoint.sh
+# COPY --from=graphdb /var/lib/neo4j /var/lib/neo4j
+# COPY --from=graphdb /logs /var/lib/neo4j/logs
+# COPY --from=graphdb /var/lib/neo4j/conf/neo4j.conf /var/lib/neo4j/conf/neo4j.conf
+# COPY --from=graphdb /data /var/lib/neo4j/data
 COPY --from=analysisservice /usr/local/tomcat/webapps/AnalysisService.war /usr/local/tomcat/webapps/AnalysisService.war
-COPY --from=contentservice /usr/local/tomcat/webapps/ContentService.war /usr/local/tomcat/webapps/ContentService.war
-COPY --from=diagrams /diagrams /usr/local/tomcat/webapps/download/current/diagram
+# COPY --from=contentservice /usr/local/tomcat/webapps/ContentService.war /usr/local/tomcat/webapps/ContentService.war
+# COPY --from=diagrams /diagrams /usr/local/tomcat/webapps/download/current/diagram
 COPY ./wait-for.sh /wait-for.sh
 
 # Set up links to fireworks files for reacfoam
@@ -111,9 +114,12 @@ ADD https://reactome.org/download/current/ehlds.tgz /usr/local/tomcat/webapps/do
 RUN cd /usr/local/tomcat/webapps/download/current && tar -zxf ehld.tgz && rm ehld.tgz
 ADD https://reactome.org/download/current/ehld/svgsummary.txt /usr/local/tomcat/webapps/download/current/ehld/svgsummary.txt
 RUN chmod a+r /usr/local/tomcat/webapps/download/current/ehld/svgsummary.txt
-
-
+RUN chown -R www-data:www-data /usr/local/diagram/static/* && ln -s /usr/local/diagram/static /usr/local/tomcat/webapps/download/current/diagram && chown -R www-data:www-data /usr/local/tomcat/webapps/download/current/diagram
+# Allow symlinks for the JSON files in /usr/local/tomcat/webapps/download/current/diagram , othwerwise, certain PwB features may not work.
+RUN mkdir -p /usr/local/tomcat/webapps/download/META-INF/ && \
+	echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Context path=\"/download\"><Resources allowLinking=\"true\"></Resources></Context>" > /usr/local/tomcat/webapps/download/META-INF/context.xml
 # load and set entrypoint
 CMD ["/entrypoint.sh"]
-RUN apt-get update && apt-get install netcat gosu procps -y && apt-get autoremove && ln -s  $(which gosu) /bin/su-exec
+# This is already done in the content-service layer
+# RUN ln -s  $(which gosu) /bin/su-exec
 # Run this as: docker run --name reactome-analysis-service -p 8080:8080 reactome/stand-alone-analysis-service:Release71

--- a/stand-alone-content-service/content-service-maven-settings.xml
+++ b/stand-alone-content-service/content-service-maven-settings.xml
@@ -100,6 +100,21 @@
                         <enabled>true</enabled>
                     </snapshots>
                 </repository>
+                <repository>
+                    <id>com.springsource.repository.bundles.release</id>
+                    <name>EBR Spring Release Repository</name>
+                    <url>http://repository.springsource.com/maven/bundles/release</url>
+                </repository>
+                <repository>
+                    <id>com.springsource.repository.bundles.external</id>
+                    <name>EBR External Release Repository</name>
+                    <url>http://repository.springsource.com/maven/bundles/external</url>
+                </repository>
+                <repository>
+                    <id>JBoss 3rd party</id>
+                    <name>JBoss 3rd party</name>
+                    <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
+                </repository>
             </repositories>
         </profile>
     </profiles>

--- a/stand-alone-content-service/content-service-maven-settings.xml
+++ b/stand-alone-content-service/content-service-maven-settings.xml
@@ -55,6 +55,12 @@
                 <fireworks.json.folder>/usr/local/tomcat/webapps/download/current/fireworks</fireworks.json.folder>
                 <report.user>report_user</report.user>
                 <report.password>report_user</report.password>
+                <!-- MySQL is needed for SBML Export -->
+                <mysql.host>localhost</mysql.host>
+                <mysql.port>3306</mysql.port>
+                <mysql.user>root</mysql.user>
+                <mysql.password>root</mysql.password>
+                <mysql.reactome.database>current</mysql.reactome.database>
             </properties>
             <repositories>
                 <!-- MAVEN central -->

--- a/stand-alone-content-service/content-service.dockerfile
+++ b/stand-alone-content-service/content-service.dockerfile
@@ -60,39 +60,23 @@ RUN mkdir -p /usr/local/diagram/static && \
 	mkdir -p /var/www/html/download/current/ehld && \
 	mkdir -p /usr/local/interactors/tuple && \
 	apt-get update && apt-get install lsb-release -y && \
-	# wget http://repo.mysql.com/mysql-apt-config_0.8.16-1_all.deb \
-	#     && echo mysql-apt-config    mysql-apt-config/repo-codename  select  bionic | debconf-set-selections \
-	#     && echo mysql-apt-config    mysql-apt-config/repo-distro    select  ubuntu | debconf-set-selections \
-	#     && echo mysql-apt-config    mysql-apt-config/select-server  select  mysql-5.7 | debconf-set-selections \
-	#     && echo mysql-apt-config    mysql-apt-config/select-product select  Ok | debconf-set-selections \
-	#     && dpkg -i mysql-apt-config_0.8.16-1_all.deb \
-	#     && apt-get update && apt-get install -y mysql-server=5.7.33-1ubuntu18.04 && \
 	apt-get install netcat gosu procps mlocate -y && \
 	apt-get autoremove && ln -s  $(which gosu) /bin/su-exec
-# RUN wget --progress=bar:force https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.34-linux-glibc2.12-i686.tar.gz && \
-# 	tar -xzf mysql-5.7.34-linux-glibc2.12-i686.tar.gz && rm mysql-5.7.34-linux-glibc2.12-i686.tar.gz && \
-# 	cp -ra mysql-5.7.34-linux-glibc2.12-i686/bin/* /usr/bin/ && \
-# 	cp -ra mysql-5.7.34-linux-glibc2.12-i686/lib/* /usr/lib/ && \
-# 	cp -ra mysql-5.7.34-linux-glibc2.12-i686/support-files/mysql.server  /etc/init.d/mysql.server && \
-# 	rm -rf  mysql-5.7.34-linux-glibc2.12-i686
 
-# RUN wget --progress=bar:force https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-community-source_5.7.34-1ubuntu18.04_amd64.deb && \
-# 	dpkg -i mysql-community-source_5.7.34-1ubuntu18.04_amd64.deb
-
-RUN wget --progress=bar:force https://downloads.mysql.com/archives/get/p/23/file/mysql-server_5.7.33-1ubuntu18.04_amd64.deb-bundle.tar
-RUN apt-get update && apt-get install libaio1 libc6 libmecab2 libnuma1 perl -y
+RUN wget --progress=bar:force https://downloads.mysql.com/archives/get/p/23/file/mysql-server_5.7.33-1ubuntu18.04_amd64.deb-bundle.tar && \
+	apt-get update && apt-get install libaio1 libc6 libmecab2 libnuma1 perl -y && \
 # MySQL requires newer version of libc6 than what is already in this docker image
-RUN tar -xf mysql-server_5.7.33-1ubuntu18.04_amd64.deb-bundle.tar && ls -lht *.deb && \
+	tar -xf mysql-server_5.7.33-1ubuntu18.04_amd64.deb-bundle.tar && ls -lht *.deb && \
 	wget --progress=bar:force http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6_2.27-3ubuntu1_amd64.deb && \
 	dpkg -i libc6_2.27-3ubuntu1_amd64.deb && \
+# OBVIOUSLY don't expose this container to the outside world! Or change the password here and in the application config.
 	echo 'mysql-community-server-5.7.33 mysql-community-server/root_password password root' | debconf-set-selections && \
 	echo 'mysql-community-server mysql-community-server/root_password password root' | debconf-set-selections  && \
 	dpkg -i mysql-common_5.7.33-1ubuntu18.04_amd64.deb && \
 	dpkg -i mysql-community-client_5.7.33-1ubuntu18.04_amd64.deb && \
 	dpkg -i mysql-client_5.7.33-1ubuntu18.04_amd64.deb && \
 	dpkg -i mysql-community-server_5.7.33-1ubuntu18.04_amd64.deb && \
-	rm -rf *.deb mysql-server_5.7.33-1ubuntu18.04_amd64.deb-bundle.tar && \
-	pwd && ls -lht
+	rm -rf *.deb mysql-server_5.7.33-1ubuntu18.04_amd64.deb-bundle.tar 
 
 # OR maybe just install MySQL from https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.34-linux-glibc2.12-i686.tar.gz
 # load and set entrypoint

--- a/stand-alone-content-service/entrypoint.sh
+++ b/stand-alone-content-service/entrypoint.sh
@@ -19,6 +19,10 @@ echo "Waiting for solr..."
 su-exec solr solr-foreground &
 bash /wait-for.sh localhost:8983 -t 90
 
+echo "Waiting for MySQL..."
+mysqld --user=root &
+bash /wait-for.sh localhost:3306 -t 120
+
 echo "Starting tomcat..."
 # Now that Neo4j and solr have been started, we can run tomcat
 cd /usr/local/tomcat

--- a/test_standalone_analysis_service.sh
+++ b/test_standalone_analysis_service.sh
@@ -72,8 +72,8 @@ check_vals_post()
   if [ "$LOCAL_VAL" != "$REMOTE_VAL" ] ; then
     echo "$VAL_NAME don't match!"
     # "jq '.'" ensures that JSON gets pretty-formatted before it's output to file. Makes debugging easier."
-    echo $LOCAL_VAL | jq '.' > /tmp/${VAL_NAME}_L
-    echo $REMOTE_VAL | jq '.' > /tmp/${VAL_NAME}_R
+    echo $LOCAL_VAL | jq -S '.' > /tmp/${VAL_NAME}_L
+    echo $REMOTE_VAL | jq -S '.' > /tmp/${VAL_NAME}_R
     diff /tmp/${VAL_NAME}_L /tmp/${VAL_NAME}_R
   else
     echo -e "$VAL_NAME test passed.\n"

--- a/test_standalone_content_service.sh
+++ b/test_standalone_content_service.sh
@@ -65,6 +65,8 @@ check_vals ContentService/data/eventsHierarchy/9606 'Human event hierarchy'
 # check_vals 'ContentService/exporter/diagram/R-HSA-177929.svg?quality=5&flgInteractors=true&title=true&margin=15&ehld=true&diagramProfile=Modern&resource=total&analysisProfile=Standard' "SVG_Export"
 # It seems like for SBGN, the order of output elements might also be non-deterministic, so I guess only SBML is going to be easy to test...
 
+# ...never mind, it seems that the elements in SBML Exports might not be in the same sequence, and it looks like even some metadata might not be exactly the same. Comparing outputs could be very difficult.
+# Verify that they are produced but don't freak out if they don't match. OR, use some sort of SBML-specific tool (if it exists) to check for diffs.
 echo -e "\nChecking SBML export"
 check_vals 'ContentService/exporter/event/R-HSA-5205682.sbml' 'SBML_Export'
 


### PR DESCRIPTION
A number of changes that needed to be made for Releaes 77. One big one was the inclusion of MySQL in the content-service image and the content-service-and-pathwaybrowser image. This is because there are changes to the SBML Exporter (which is a dependency of content-service and content-service is a dependency of PathwayBrowser) such that it now requires the relational database to generate the SBML files. The main impact of this is that MySQL is installed into the content-service image, and then the PathwayBrowser is now based on the content-service image instead of a more generic Tomcat image, since the content-service image _already_ includes tomcat, as well as Neo4j, solr, MySQL, and all of the other content files (such as fireworks and diagrams).

There are also changes to the maven settings file for content-service to include some repositories that contain dependencies that were not downloading correctly from an old EBI maven repository server.